### PR TITLE
DEVOPS-2691 - fixing a dependency issue with ohai

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.7.7'
+version           '2.7.8'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'
@@ -11,7 +11,7 @@ recipe 'nginx::source', 'Installs nginx from source and sets up configuration wi
 depends 'apt'
 depends 'bluepill'
 depends 'build-essential'
-depends 'ohai', '< 4.0.0'
+depends 'ohai'
 depends 'runit'
 depends 'yum-epel'
 


### PR DESCRIPTION
Ticket reference: https://jira.rallyhealth.com/browse/DEVOPS-2691

Removing the constraint on `ohai` as it is now having the opposite affect of breaking CI environments with the latest upgrade of our internal mongo cookbook: https://github.com/AudaxHealthInc/rally-mongodb-cookbook/compare/v0.3.6...v0.4.0#diff-9fd042d4cd1e8f82894bbd7dffb313ec

The constraint on that version is now: https://github.com/chef-cookbooks/aws/blob/master/metadata.rb#L14

This should fix the environments where the latest mongo was introduced.

cc: @mrsipan @mfbaker @toofishes 