### PR TITLE
OHLP-1075 - fix the ohai plugin for latest ~> 4.2.0 release

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.7.8'
+version           '2.7.9'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -24,11 +24,9 @@ ohai 'reload_nginx' do
   action :nothing
 end
 
-template "#{node['ohai']['plugin_path']}/nginx.rb" do
-  source 'plugins/nginx.rb.erb'
-  owner  'root'
-  group  node['root_group']
-  mode   '0755'
+ohai_plugin 'nginx' do
+  source_file 'plugins/nginx.rb.erb'
+  resource :template
   notifies :reload, 'ohai[reload_nginx]', :immediately
 end
 


### PR DESCRIPTION
Ticket reference: https://jira.rallyhealth.com/browse/OHLP-1075

With the latest update yesterday (https://github.com/AudaxHealthInc/nginx/pull/4) it allowed us to upgrade to ohai > 4.0.0 which it was previously pinned to, that other cookbooks we have depend on. As a result we need to upgrade the provider in this cookbook to use the new syntax.

cc: @mrsipan @mfbaker @toofishes