### PR TITLE
do nginx upgrade when notifies a :reload

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs and configures nginx'
-version           '2.7.9'
+version           '2.7.10'
 
 recipe 'nginx',         'Installs nginx package and sets up configuration with Debian apache style with sites-enabled/sites-available'
 recipe 'nginx::source', 'Installs nginx from source and sets up configuration with Debian apache style with sites-enabled/sites-available'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@
 include_recipe "nginx::#{node['nginx']['install_method']}"
 
 service 'nginx' do
+  reload_command '/etc/init.d/nginx upgrade'
   supports :status => true, :restart => true, :reload => true
   action   :start
 end


### PR DESCRIPTION
In certain situations nginx cannot do a clean service `reload` and we also don't want to break connections with a service `restart`.

@mfbaker suggested that we could try to swap the _nginx_ processes by [sending a `USR2`](http://nginx.org/en/docs/control.html) signal to the master process. More details can be found [here](https://www.digitalocean.com/community/tutorials/how-to-upgrade-nginx-in-place-without-dropping-client-connections).

Ubuntu 14.04 does come with an `upgrade` option for the nginx initscript. We could use it to redefine `command_reload`.

cc: @mfbaker @tylermarshall @mattbrown @rlyeroberts 